### PR TITLE
Only convert active columns to r4

### DIFF
--- a/src/physics/cam/physics_buffer.F90.in
+++ b/src/physics/cam/physics_buffer.F90.in
@@ -167,8 +167,10 @@ module physics_buffer
   !
   ! private pio descriptor for time
   !
-
   type(var_desc_t) :: timeidx_desc
+
+  ! Set to .true. for more output
+  logical :: debug = .false.
 
 !===============================================================================
 CONTAINS
@@ -765,7 +767,7 @@ end subroutine pbuf_readnl
     integer                            :: ind
     type(physics_buffer_desc), pointer :: pbufPtr
 
-    if (masterproc) then
+    if (masterproc .and. debug) then
        write(iulog, *) __FILE__, __LINE__, currentpbufflds, size(pbuf)
        do ind = 1, currentpbufflds
           pbufPtr => pbuf(ind)


### PR DESCRIPTION
All aux_cam run (on Izumi) with this fix, nag has baseline and compare failures.