### PR TITLE
mods needed to pass ERP test

### DIFF
--- a/src/cpl/mct/atm_comp_mct.F90
+++ b/src/cpl/mct/atm_comp_mct.F90
@@ -358,7 +358,7 @@ CONTAINS
        end if
 
        ! Compute time of next radiation computation
-       nextsw_cday = radiation_nextsw_cday()
+       nextsw_cday = radiation_nextsw_cday(init=.true.)
        call seq_infodata_PutData( infodata, nextsw_cday=nextsw_cday )
 
        ! End redirection of share output to cam log

--- a/src/cpl/nuopc/atm_comp_nuopc.F90
+++ b/src/cpl/nuopc/atm_comp_nuopc.F90
@@ -885,7 +885,7 @@ contains
        end if
 
        ! Compute time of next radiation computation
-       nextsw_cday = radiation_nextsw_cday()
+       nextsw_cday = radiation_nextsw_cday(init=.true.)
        call State_SetScalar(nextsw_cday, flds_scalar_index_nextsw_cday, exportState, &
             flds_scalar_name, flds_scalar_num, rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return

--- a/src/physics/cam/micro_mg_cam.F90
+++ b/src/physics/cam/micro_mg_cam.F90
@@ -1382,6 +1382,8 @@ subroutine micro_mg_cam_init(pbuf2d)
       call pbuf_set_field(pbuf2d, evpsnow_st_idx, 0._r8)
       call pbuf_set_field(pbuf2d, prer_evap_idx,  0._r8)
       call pbuf_set_field(pbuf2d, bergso_idx, 0._r8)
+      call pbuf_set_field(pbuf2d, icswp_idx, 0._r8)
+      call pbuf_set_field(pbuf2d, cldfsnow_idx, 0._r8)
 
       if (qrain_idx > 0)   call pbuf_set_field(pbuf2d, qrain_idx, 0._r8)
       if (qsnow_idx > 0)   call pbuf_set_field(pbuf2d, qsnow_idx, 0._r8)
@@ -1400,14 +1402,16 @@ subroutine micro_mg_cam_init(pbuf2d)
 
       ! If sub-columns turned on, need to set the sub-column fields as well
       if (use_subcol_microp) then
-         call pbuf_set_field(pbuf2d, cldo_idx,   0._r8, col_type=col_type_subcol)
-         call pbuf_set_field(pbuf2d, cc_t_idx,   0._r8, col_type=col_type_subcol)
-         call pbuf_set_field(pbuf2d, cc_qv_idx,  0._r8, col_type=col_type_subcol)
-         call pbuf_set_field(pbuf2d, cc_ql_idx,  0._r8, col_type=col_type_subcol)
-         call pbuf_set_field(pbuf2d, cc_qi_idx,  0._r8, col_type=col_type_subcol)
-         call pbuf_set_field(pbuf2d, cc_nl_idx,  0._r8, col_type=col_type_subcol)
-         call pbuf_set_field(pbuf2d, cc_ni_idx,  0._r8, col_type=col_type_subcol)
-         call pbuf_set_field(pbuf2d, cc_qlst_idx,0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cldo_idx,    0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cc_t_idx,    0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cc_qv_idx,   0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cc_ql_idx,   0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cc_qi_idx,   0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cc_nl_idx,   0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cc_ni_idx,   0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cc_qlst_idx, 0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, icswp_idx,   0._r8, col_type=col_type_subcol)
+         call pbuf_set_field(pbuf2d, cldfsnow_idx,0._r8, col_type=col_type_subcol)
       end if
 
    end if

--- a/src/physics/cam_dev/physpkg.F90
+++ b/src/physics/cam_dev/physpkg.F90
@@ -1477,7 +1477,7 @@ contains
 
     if (cmfmczm_idx > 0) then
       call pbuf_get_field(pbuf, cmfmczm_idx, cmfmczm)
-      cmfmc(:ncol,:) = cmfmczm
+      cmfmc(:ncol,:) = cmfmczm(:ncol,:)
     else
       cmfmc(:ncol,:) = 0._r8
     end if

--- a/src/physics/camrt/radiation.F90
+++ b/src/physics/camrt/radiation.F90
@@ -312,9 +312,10 @@ end function radiation_do
 
 !================================================================================================
 
-real(r8) function radiation_nextsw_cday()
+real(r8) function radiation_nextsw_cday(init)
   
    ! Returns calendar day of next sw radiation calculation
+   logical, intent(in), optional :: init
 
    ! Local variables
    integer :: nstep      ! timestep counter

--- a/src/physics/rrtmg/radiation.F90
+++ b/src/physics/rrtmg/radiation.F90
@@ -318,9 +318,9 @@ real(r8) function radiation_nextsw_cday(init)
    use phys_control,   only: cam_physpkg_is 
   
    ! Return calendar day of next sw radiation calculation
+   logical, intent(in), optional :: init
 
    ! Local variables
-   logical, intent(in), optional :: init
    logical :: doinit     ! flag indicating call occurs during initialization
    integer :: nstep      ! timestep counter
    logical :: dosw       ! true => do shosrtwave calc   

--- a/src/physics/rrtmg/radiation.F90
+++ b/src/physics/rrtmg/radiation.F90
@@ -313,11 +313,15 @@ end function radiation_do
 
 !================================================================================================
 
-real(r8) function radiation_nextsw_cday()
+real(r8) function radiation_nextsw_cday(init)
+
+   use phys_control,   only: cam_physpkg_is 
   
    ! Return calendar day of next sw radiation calculation
 
    ! Local variables
+   logical, intent(in), optional :: init
+   logical :: doinit     ! flag indicating call occurs during initialization
    integer :: nstep      ! timestep counter
    logical :: dosw       ! true => do shosrtwave calc   
    integer :: offset     ! offset for calendar day calculation
@@ -326,11 +330,24 @@ real(r8) function radiation_nextsw_cday()
    real(r8):: caldayp1   ! calendar day of next time-step
    !-----------------------------------------------------------------------
 
+   if (present(init)) then
+     doinit = init
+   else
+     doinit = .false.
+   end if
+
    radiation_nextsw_cday = -1._r8
    dosw   = .false.
    nstep  = get_nstep()
    dtime  = get_step_size()
    offset = 0
+
+   ! wind back the clock to characterize radiation in restarts (for suites w/ radiation in tphysac)
+   if (doinit .and. is_first_restart_step() .and. cam_physpkg_is("cam_dev")) then
+     nstep = nstep - 1
+     offset = offset - dtime
+   end if
+
    do while (.not. dosw)
       nstep = nstep + 1
       offset = offset + dtime
@@ -345,9 +362,14 @@ real(r8) function radiation_nextsw_cday()
 
    ! determine if next radiation time-step not equal to next time-step
    if (get_nstep() >= 1) then
-      caldayp1 = get_curr_calday(offset=int(dtime))
+      if (doinit .and. is_first_restart_step() .and. cam_physpkg_is("cam_dev")) then
+        caldayp1 = get_curr_calday()
+      else
+        caldayp1 = get_curr_calday(offset=int(dtime))
+      end if
       if (caldayp1 /= radiation_nextsw_cday) radiation_nextsw_cday = -1._r8
    end if    
+
 end function radiation_nextsw_cday
 
 !================================================================================================

--- a/src/physics/simple/radiation.F90
+++ b/src/physics/simple/radiation.F90
@@ -44,10 +44,11 @@ end function radiation_do
 
 !========================================================================================
 
-real(r8) function radiation_nextsw_cday()
+real(r8) function radiation_nextsw_cday(init)
   
    ! Returns calendar day of next sw radiation calculation
    !---------------------------------------------------------------------------
+   logical, intent(in), optional :: init
 
    radiation_nextsw_cday = -1._r8
 


### PR DESCRIPTION
Hi Cheryl,

Doing a PR to your branch slated for https://github.com/ESCOMP/CAM/pull/490. This PR includes two bug fixes. (1) a bug in cmfmczm indexing in cam_dev/physpkg.F90, and (2) changes to nextsw_cday function during initialization phase of restart runs. The (1) bug only created problems with really coarse grids where pcol is less than 16. The (2) bug fix is required to pass the COMPARE_base_rest. Here is the output from an ERP test:

  ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s (Overall: PASS) details:
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s CREATE_NEWCASE
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s XML
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s SETUP
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s SHAREDLIB_BUILD time=496
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s MODEL_BUILD time=720
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s SUBMIT
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s RUN time=637
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s COMPARE_base_rest
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s MEMLEAK insuffiencient data for memleak test
    PASS ERP_D_Ln9_Vmct.f10_f10_mg37.F2000dev.izumi_nag.cam-outfrq9s SHORT_TERM_ARCHIVER

Note that I switch the zm_parcel namelist off for these tests. Let me know if you want me to do more testing before merging this PR. I have also passed this test with f19_f19_mg17. I seem to have trouble compiling ne30pg3_ne30pg3_mg17 on izumi, so that's why I didn't use that grid for testing.