### PR TITLE
Fix physgrid attributes for history file with only physgrid output

### DIFF
--- a/src/dynamics/se/dyn_grid.F90
+++ b/src/dynamics/se/dyn_grid.F90
@@ -546,10 +546,9 @@ subroutine physgrid_copy_attributes_d(gridname, grid_attribute_names)
       grid_attribute_names(2) = 'ne'
    else
       gridname = 'GLL'
-      allocate(grid_attribute_names(3))
-      grid_attribute_names(1) = 'area_d'
-      grid_attribute_names(2) = 'np'
-      grid_attribute_names(3) = 'ne'
+      allocate(grid_attribute_names(2))
+      grid_attribute_names(1) = 'np'
+      grid_attribute_names(2) = 'ne'
    end if
 
 end subroutine physgrid_copy_attributes_d

--- a/src/utils/cam_grid_support.F90
+++ b/src/utils/cam_grid_support.F90
@@ -2203,7 +2203,7 @@ contains
   subroutine write_cam_grid_attr_1d_int(attr, File)
     use pio,           only: file_desc_t, pio_put_att, pio_noerr
     use pio,           only: pio_inq_dimid, pio_int
-    use cam_pio_utils, only: cam_pio_def_var
+    use cam_pio_utils, only: cam_pio_def_var, cam_pio_closefile
 
     ! Dummy arguments
     class(cam_grid_attribute_1d_int_t), intent(inout) :: attr
@@ -2224,6 +2224,7 @@ contains
         ! NB: It should have been defined as part of a coordinate
         write(errormsg, *) 'write_cam_grid_attr_1d_int: dimension, ',         &
              trim(attr%dimname), ', does not exist'
+        call cam_pio_closefile(File)
         call endrun(errormsg)
       end if
       ! Time to define the variable
@@ -2247,7 +2248,7 @@ contains
   subroutine write_cam_grid_attr_1d_r8(attr, File)
     use pio,           only: file_desc_t, pio_put_att, pio_noerr, pio_double, &
          pio_inq_dimid
-    use cam_pio_utils, only: cam_pio_def_var
+    use cam_pio_utils, only: cam_pio_def_var, cam_pio_closefile
 
     ! Dummy arguments
     class(cam_grid_attribute_1d_r8_t), intent(inout) :: attr
@@ -2268,6 +2269,7 @@ contains
         ! NB: It should have been defined as part of a coordinate
         write(errormsg, *) 'write_cam_grid_attr_1d_r8: dimension, ',          &
              trim(attr%dimname), ', does not exist'
+        call cam_pio_closefile(File)
         call endrun(errormsg)
       end if
       ! Time to define the variable


### PR DESCRIPTION
Should fix issue with `PLB_D_Ln9_Vmct.ne5_ne5_mg37.QPC5.izumi_nag.cam-ttrac_loadbal0` test.
Will sometime result in duplicate area attribute on history files (i.e., both `area` and `area_d` with the same data).